### PR TITLE
fixes ie wrapping for labels

### DIFF
--- a/skins/item/children/item-label.ess
+++ b/skins/item/children/item-label.ess
@@ -1,5 +1,6 @@
 color inherit
-flex-grow 1
+display block
+flex 1
 line-height 1.45em
 padding 8px 0
 text-align left


### PR DESCRIPTION
This is the problem:
![screen_shot_2015-11-03_at_11 41 11_am](https://cloud.githubusercontent.com/assets/991316/11288458/7a85b322-8ee1-11e5-8712-908f12749c6a.png)


For some reason, IE prefers `flex 1` over `flex-grow 1` Adding this and `display block` lets the element wrap with padding.
![windows_screenshot](https://cloud.githubusercontent.com/assets/991316/11288564/731750f4-8ee2-11e5-8469-1e107efc0953.png)
