### PR TITLE
apply '&-className' to each base class name

### DIFF
--- a/utils/seed-classes.js
+++ b/utils/seed-classes.js
@@ -4,8 +4,7 @@ export default function(base, statuses = {}, classes = {}) {
   if (classes[base]) base = classes[base];
 
   var rootStatuses = addStatuses(statuses);
-  var baseRegExp = new RegExp('^' + base + '-?');
-
+  
   return function(className, classStatuses) {
     var allStatuses = classStatuses
       ? addStatuses(classStatuses, rootStatuses)
@@ -13,17 +12,13 @@ export default function(base, statuses = {}, classes = {}) {
 
     if (classes[className]) className = classes[className];
 
-    var baseClassName = typeof className === 'string'
-      ? className.replace('&', base)
-      : base + '';
-
-    if (classes[baseClassName]) baseClassName = classes[baseClassName];
-
-    var statusClasses = allStatuses.length
-      ? baseClassName + allStatuses.join(' ' + baseClassName)
-      : '';
-
-    return `${baseClassName} ${statusClasses}`.trim();
+    return base.split(' ').map(function (b) {
+      var baseClassName = typeof className === 'string' ? className.replace('&', b) : b + '';
+      baseClassName = classes[baseClassName] ? classes[baseClassName] : baseClassName;
+      var statusClasses = allStatuses.length ? baseClassName + allStatuses.join(' ' + baseClassName) : '';
+      
+      return `${baseClassName} ${statusClasses}`.trim();
+    }).join(' ');
   };
 }
 


### PR DESCRIPTION
It was only applying the postfix to the last class assigned to the element.
Helpful when you apply a className to a component. The expected behavior would be to apply the & postfix to each of the original classes on the element.

I.E.
```jade
.Quizzes-component.is-loaded(classFn('&-side-toggle'))
```
compiles into
```html
<div class="Quizzes-component is-loaded Quizzes-component-side-toggle is-loaded-side-toggle"></div>
```