### PR TITLE
support prop value for compose classes key

### DIFF
--- a/utils/seed-classes.js
+++ b/utils/seed-classes.js
@@ -1,4 +1,4 @@
-import appendStatus from './append-status';
+import appendStatus from './append-status'
 
 export default function(base, statuses = {}, classes = {}) {
   if (classes[base]) base = classes[base];
@@ -24,7 +24,7 @@ export default function(base, statuses = {}, classes = {}) {
 
 function addStatuses(sx, arr = []) {
   for (var s in sx) {
-    arr.push('-' + appendStatus(sx[s], s));
+    arr.push('-' + appendStatus(sx[s], s.replace('@', sx[s])));
   }
   return arr;
 }


### PR DESCRIPTION
This allows us to pass a prop value as a status and have it return only one class
i.e.
`this.composeClasses('ColorPicker', {'size-@': props.size})`
Will result in a status class of:
`ColorPicker-is-size-small`

As opposed to listing all possibilities as such:
`this.composeClasses('ColorPicker', {'small': size === 'small', 'normal': size === 'normal', 'flex': size === 'flex', 'round': size === 'round' 'selected': selected})`