### PR TITLE
add input-item and growing input components

### DIFF
--- a/controls/growing-input/index.ess
+++ b/controls/growing-input/index.ess
@@ -1,0 +1,7 @@
+.UIGrowingInput
+  &-component
+    box-sizing border-box
+    display block
+    overflow hidden
+    position relative
+    resize none

--- a/controls/growing-input/index.jade
+++ b/controls/growing-input/index.jade
@@ -1,0 +1,112 @@
+:doc
+  @name UIGrowingInput
+  @prop {Boolean} readonly
+  @prop {Boolean} required
+  @prop {Boolean} shouldAutoFocus
+  @prop {Function} onBlur
+  @prop {Function} onChange
+  @prop {Function} onFocus
+  @prop {Function} onKeydown
+  @prop {Object} template
+  @prop {Number} maxLength
+  @prop {Number} minLength
+  @prop {String} className
+  @prop {String} defaultValue
+  @prop {String} type
+
+import {KEY_NAMES} from 'ui-kit/utils/keybinding.js'
+import * as debounce from 'debounce'
+
+import './index.ess'
+
+var.
+  componentProps = {
+    className: props.className,
+    defaultValue: props.defaultValue,
+    maxLength: props.maxLength,
+    minLength: props.minLength,
+    onBlur: this.onBlur,
+    onFocus: this.onFocus,
+    onChange: this.onChange,
+    onKeyDown: this.onKeyDown,
+    placeholder: props.placeholder,
+    readonly: props.readonly,
+    required: props.required,
+    style: props.style,
+    tabIndex: props.tabIndex,
+    type: 'textarea'
+  }
+
+var useAutoId = !!props.label && !props.id
+var id = useAutoId ? this.getNextUid('InputComponent') : props.id
+var labelFor = useAutoId ? this.getNextUid('InputComponent') : props.id
+var value = (state.value || state.value === '' ) ? state.value : props.defaultValue
+
+textarea(id=id rows='1' autoFocus=props.shouldAutoFocus value=value)&props(componentProps)
+-this.recalculateSize();
+
+:module
+  export function getDefaultProps () {
+    return {
+      submitOnEnter: true
+    };
+  }
+
+  export function componentWillMount () {
+    this.recalculateSize = debounce(this.recalculateSize, 100);
+    this.submitTemplate = debounce(this.submitTemplate, 500);
+  }
+
+  export function componentWillReceiveProps (props) {
+    if (props.defaultValue !== this.props.defaultValue && !this.state.hasFocus) this.setState({value: props.defaultValue});
+    if (props.shouldAutoFocus && props.shouldAutoFocus !== this.props.shouldAutoFocus) this.getDOMNode().focus();
+    return true;
+  }
+
+  export function onBlur (ev) {
+    this.setState({hasFocus: false});
+    if (this.props.onBlur) this.props.onBlur.apply(this, arguments);
+  }
+
+  export function onFocus (ev) {
+    this.setState({hasFocus: true});
+    if (this.props.onFocus) this.props.onFocus.apply(this, arguments);
+  }
+
+  export function onChange (ev) {
+    var value = ev.target.value;
+    this.setState({value: value});
+    if (this.props.onChange) this.props.onChange.apply(null, arguments);
+    this.submitTemplate();
+    this.recalculateSize();
+  }
+
+  export function recalculateSize () {
+    if (!this.isMounted()) return;
+    var input = this.getDOMNode();
+    input.style.height = '';
+    var newHeight = input.scrollHeight;
+    input.style.height = [newHeight, 'px'].join('');
+  }
+
+  export function onKeyDown (evt) {
+    if (this.props.onKeyDown) this.props.onKeyDown.apply(null, arguments);
+    if (this.props.submitOnEnter === true && evt.keyCode === KEY_NAMES.enter) {
+      evt.preventDefault();
+      this.submitTemplate();
+    }
+  }
+
+  export function submitTemplate () {
+    if (!this.props.template) return;
+    var value = this.getDOMNode().value.trim();
+    this.context.forms.create(this.props.template)
+      .set({value: value})
+      .submit((err, res) => {
+        if (err) {
+          if (this.props.onError) this.props.onError(err);
+          console.warn(err);
+        }
+
+      });
+  }

--- a/controls/input-item/index.jade
+++ b/controls/input-item/index.jade
@@ -1,0 +1,110 @@
+:doc
+  @name UIInputItem
+  @prop {Boolean} [multiLine]
+  @prop {Boolean} [noTemplate]
+  @prop {Boolean} [readonly]
+  @prop {Boolean} [required]
+  @prop {Boolean} [shouldAutoFocus]
+  @prop {Function} [onBlur]
+  @prop {Function} [onChange]
+  @prop {Function} [onFocus]
+  @prop {Function} [onKeydown]
+  @prop {Number} [maxLength]
+  @prop {Number} [minLength]
+  @prop {Object} [template]
+  @prop {String} [className]
+  @prop {String} [defaultValue]
+  @prop {String} [type]
+
+import {KEY_NAMES} from 'ui-kit/utils/keybinding.js'
+import AutoInputSave from 'ui-kit/controls/auto-input-save'
+import GrowingInput from '../growing-input'
+
+var.
+  componentProps = {
+    defaultValue: props.defaultValue,
+    maxLength: props.maxLength,
+    minLength: props.minLength,
+    placeholder: props.placeholder,
+    readonly: props.readonly,
+    required: props.required,
+    shouldAutoFocus: props.shouldAutoFocus,
+    style: props.style,
+    tabIndex: props.tabIndex,
+    type: props.multiLine ? 'textarea' : props.type
+  }
+
+var classFn = this.composeClasses('MUIInputItem', {'value': !!state.hasValue, 'multi': componentProps.type === 'textarea', 'labeled': !!props.label})
+
+var useAutoId = (!!props.label || !!props.labelBlock) && !props.inputId
+var inputId = useAutoId ? this.getNextUid('MUIInputItemComponent') : props.inputId
+var labelFor = useAutoId ? this.getNextUid('MUIInputItemComponent') : props.inputId
+var labelClass = classFn('&-label')
+var value = (state.value || state.value === '' ) ? state.value : props.defaultValue
+
+.is-input(className=classFn())
+  if props.template
+    AutoInputSave(template=props.template)
+      block input(savedValue, fns)
+        = inputContent(fns.onChange)
+        yield icon
+  else if props.noTemplate
+    = inputContent()
+    yield icon
+
+function inputContent(onChange)
+  div(className=classFn('&-content'))
+    yield actions
+    if componentProps.type !== 'textarea' && !props.multiLine
+      input(autoFocus=props.shouldAutoFocus id=inputId className=classFn('&-input') onKeyDown=this.onKeyDown.bind(null, onChange) onFocus=this.onInputFocus onBlur=this.onInputBlur onChange=this.onChange.bind(null, onChange) value=value)&props(componentProps)
+    else
+      GrowingInput(id=inputId className=classFn('&-input') onKeyDown=this.onKeyDown.bind(null, onChange) onFocus=props.onFocus onBlur=props.onBlur onChange=this.onChange.bind(null, onChange))&props(componentProps)
+    if !!props.label
+      label(for=labelFor className=labelClass)=props.label
+    yield labelBlock(labelFor, labelClass)
+
+:module
+  export var mixins = [require('ui-kit/mixins/compose-classes'), require('unique-id-mixin')]
+
+  export function getDefaultProps () {
+    return {
+      submitOnEnter: true,
+      type: 'text'
+    };
+  }
+
+  export function getInitialState () {
+    return {
+      hasValue: !!this.props.defaultValue
+    };
+  }
+
+  export function componentWillReceiveProps (props) {
+    if (props.defaultValue !== this.props.defaultValue && !this.state.hasFocus) this.setState({value: props.defaultValue});
+  }
+
+  export function onInputFocus () {
+    this.setState({hasFocus: true});
+    if (this.props.onFocus) this.props.onFocus.apply(null, arguments);
+  }
+
+  export function onKeyDown (onChange, evt) {
+    if (this.props.submitOnEnter && evt.keyCode === KEY_NAMES.enter) {
+      evt.preventDefault();
+      this.onChange(onChange, evt);
+    }
+  }
+
+  export function onInputBlur () {
+    this.setState({hasFocus: false});
+    if (this.props.onBlur) this.props.onBlur.apply(null, arguments);
+  }
+
+  export function onChange (autoSave, ev) {
+    var value = ev.target.value;
+    var hasValue = !!value;
+    if (this.props.onChange) this.props.onChange.apply(null, arguments);
+    if (this.state.hasValue !== hasValue) this.setState({hasValue: hasValue});
+    this.setState({value: value});
+    if (autoSave) autoSave(ev, value.trim());
+  }


### PR DESCRIPTION
InputItem is an item that takes a template for auto-save and has a
structure for items. No style is applied, for easy skinning.
GrowingInput is used here to separate responsibility and offer easy
growing input which also accepts an optional template.