### PR TITLE
use confirm dropdown in submit with message prop

### DIFF
--- a/components/confirm-dropdown/index.jade
+++ b/components/confirm-dropdown/index.jade
@@ -6,6 +6,7 @@
   @prop {String} confirmLabel - Label for confirm button
   @prop {String} [confirmKeybinding='enter'] - Keyboard key that will trigger confirm, can be set to a falsey value
   @prop {String} [message] - Optional String, but puts buttons at the bottom of the menu
+  @prop {String} [position] Inherits Flyout:position
   @prop {Function} [onCancelClick] - Called when cancel, or close button (if shown) is clicked
   @prop {Function} [onConfirmClick] - Called when confirm is clicked
   @prop {Function} [onHide] - Called any time this menu hides (including onConfirmClick)
@@ -17,7 +18,7 @@ import './index.ess'
 
 var classFn = this.composeClasses('UIConfirmDropdown', {'type-@':props.type, 'has-message': !!props.message})
 
-Flyout(className=classFn() showMenuOnLoad onHide=props.onHide hideMenuKeyBinding=props.cancelKeybinding)
+Flyout(className=classFn() showMenuOnLoad onHide=props.onHide onKeybindingPress=this.onKeybindingPress onWindowClickHide=this.onCancelClick hideMenuKeyBinding=props.cancelKeybinding position=props.position)
   block menu(actions)
     if (props.message)
       div(className=classFn('UIConfirmDropdown-message'))
@@ -66,4 +67,8 @@ Flyout(className=classFn() showMenuOnLoad onHide=props.onHide hideMenuKeyBinding
 
   export function onEnterPress () {
     this.onConfirmClick();
+  }
+
+  export function onKeybindingPress (action) {
+    if (action === 'hide') this.onCancelClick();
   }

--- a/controls/flyout/index.jade
+++ b/controls/flyout/index.jade
@@ -15,18 +15,22 @@
   @prop {String}   [hideMenuKeyBinding] key to listen for that will hide flyout
   @prop {String}   [showMenuKeyBinding] key to listen for that will show flyout
   @prop {String}   [toggleMenuKeyBinding] key to listen for that will toggle flyout
+  @prop {Function} [onShow] called after flyout shows
+  @prop {Function} [onHide] called after flyout hides
+  @prop {Function} [onWindowClickHide] this is called when flyout will hide because of clicking outside the menu (onHide will also be called)
   @prop {Function} [onComponentWillHide] called when component will hide
   @prop {Funciton} [onComponentWillShow] called when component will show
+  @prop {Function} [onKeybindingPress] called when a keybinding is pressed
+    @arg {String} action - the keybinding action called (show, hide, toggle)
 
 import * as scrollToElement from 'scroll-to-element'
 import elContains from '../../utils/element-contains-el'
-import {attachKeybinding, removeKeybindings} from '../../utils/keybinding.js'
+import {attachKeybinding, removeKeybindings, hasKeybinding} from '../../utils/keybinding.js'
 
 :js
   var classFn = this.composeClasses('UIFlyout', {
     'active': state.isActive,
-    'has-trigger': props.trigger,
-    'position-@': props.position
+    'has-trigger': !!props.trigger
   })
 
   var fns= {
@@ -38,7 +42,8 @@ import {attachKeybinding, removeKeybindings} from '../../utils/keybinding.js'
   var menuStates = {
     'showing': state.isActive,
     'animating-show': state.showMenuStarted,
-    'animating-hide': state.hideMenuStarted
+    'animating-hide': state.hideMenuStarted,
+    'position-@': props.position
   }
 
 div(className=classFn())
@@ -60,6 +65,7 @@ div(className=classFn())
 
   export function getDefaultProps () {
     return {
+      position: 'bottom-middle',
       animationTimeout: 0,
       scrollToMenu: {}
     };
@@ -67,26 +73,26 @@ div(className=classFn())
 
   export function componentDidMount () {
     if (this.props.showMenuKeyBinding) {
-      attachKeybinding(this.props.showMenuKeyBinding, this.startShowingMenu);
+      attachKeybinding(this.props.showMenuKeyBinding, this.onKeybindingPress.bind(null, 'show'));
     }
     if (this.props.toggleMenuKeyBinding) {
-      attachKeybinding(this.props.toggleMenuKeyBinding, this.toggleMenu);
+      attachKeybinding(this.props.toggleMenuKeyBinding, this.onKeybindingPress.bind(null, 'toggle'));
     }
     if (this.props.showMenuOnLoad) this.startShowingMenu();
   }
 
   export function componentWillReceiveProps (nextProps) {
-    if (nextProps.showMenuKeyBinding !== this.props.showMenuKeyBinding) {
+    if (nextProps.showMenuKeyBinding !== this.props.showMenuKeyBinding && hasKeybinding(this.props.showMenuKeyBinding)) {
       removeKeybindings(this.props.showMenuKeyBinding);
-      attachKeybinding(nextProps.showMenuKeyBinding, this.startShowingMenu);
+      attachKeybinding(nextProps.showMenuKeyBinding, this.onKeybindingPress.bind(null, 'show'));
     }
-    if (nextProps.hideMenuKeyBinding !== this.props.hideMenuKeyBinding) {
+    if (nextProps.hideMenuKeyBinding !== this.props.hideMenuKeyBinding && hasKeybinding(this.props.hideMenuKeyBinding)) {
       removeKeybindings(this.props.hideMenuKeyBinding);
-      attachKeybinding(nextProps.hideMenuKeyBinding, this.startHidingMenu);
+      attachKeybinding(nextProps.hideMenuKeyBinding, this.onKeybindingPress.bind(null, 'hide'));
     }
-    if (nextProps.toggleMenuKeyBinding !== this.props.toggleMenuKeyBinding) {
+    if (nextProps.toggleMenuKeyBinding !== this.props.toggleMenuKeyBinding && hasKeybinding(this.props.toggleMenuKeyBinding)) {
       removeKeybindings(this.props.toggleMenuKeyBinding);
-      attachKeybinding(nextProps.toggleMenuKeyBinding, this.toggleMenu);
+      attachKeybinding(nextProps.toggleMenuKeyBinding, this.onKeybindingPress.bind(null, 'toggle'));
     }
     if (nextProps.showMenuOnLoad && !this.state.hasShownMenu) {
       this.startShowingMenu();
@@ -124,6 +130,21 @@ div(className=classFn())
     if (this.state.isActive && this.props.onHide) this.props.onHide();
   }
 
+  export function onKeybindingPress (action) {
+    if (this.props.onKeybindingPress) this.props.onKeybindingPress(action);
+    switch (action) {
+      case 'toggle':
+        this.toggleMenu();
+        break;
+      case 'show':
+        this.startShowingMenu();
+        break;
+      case 'hide':
+        this.startHidingMenu();
+        break;
+    }
+  }
+
   export function toggleMenu (evt) {
     this.state.isActive ?
       this.startHidingMenu(evt) :
@@ -133,7 +154,7 @@ div(className=classFn())
   export function startShowingMenu (evt) {
     if (this.state.isActive) return;
     if (this.props.showMenuKeyBinding) removeKeybindings(this.props.showMenuKeyBinding);
-    if (this.props.hideMenuKeyBinding) attachKeybinding(this.props.hideMenuKeyBinding, this.startHidingMenu);
+    if (this.props.hideMenuKeyBinding) attachKeybinding(this.props.hideMenuKeyBinding, this.onKeybindingPress.bind(null, 'hide'));
     this.setState({showMenuStarted: true, hasShownMenu: true});
   }
 
@@ -141,7 +162,7 @@ div(className=classFn())
     if (!this.state.isActive) return;
     if (evt) evt.stopPropagation();
     if (this.props.hideMenuKeyBinding) removeKeybindings(this.props.hideMenuKeyBinding);
-    if (this.props.showMenuKeyBinding) attachKeybinding(this.props.showMenuKeyBinding, this.startShowingMenu);
+    if (this.props.showMenuKeyBinding) attachKeybinding(this.props.showMenuKeyBinding, this.onKeybindingPress.bind(null, 'show'));
     this.setState({hideMenuStarted: true});
     window.removeEventListener('click', this.onWindowClick);
   }
@@ -176,6 +197,7 @@ div(className=classFn())
     if (!this.isMounted()) return;
     var el = this.getDOMNode();
     if (this.props.hideOnClick || !elContains(el, evt.target)) {
+      if (this.props.onWindowClickHide && !elContains(el, evt.target)) this.props.onWindowClickHide();
       this.startHidingMenu();
     }
   }

--- a/controls/submit/index.jade
+++ b/controls/submit/index.jade
@@ -1,18 +1,53 @@
 :doc
-  @name Submit
-  @prop {String} className
-  @prop {String} confirmMessage
-  @prop {Function} onFinish
-  @prop {Function} onStart
-  @prop {Object} template
+  @name UISubmit
+  @prop {Function} [onFinish]
+  @prop {Function} [onStart]
+  @prop {Object}    template
+  //-- message props
+  @prop {Boolean} [useSystemDialog] - Uses system dialog over confirm dropdown
+  @prop {String}  [confirmMessage] - The message to use before submitting
+  @prop {String}  [messageConfirmLabel] - see ConfirmDropdown:confirmLabel
+  @prop {String}  [messageCancelLabel] - see ConfirmDropdown:cancelLabel
+  @prop {String}  [messagePosition] - see ConfirmDropdown:position
+  @prop {String}  [messageType] - see ConfirmDropdown:type
+  @prop {Function}[onCancel] - called onCancelClick in ConfirmDropdown
+  //--
+import ConfirmDropdown from '../../components/confirm-dropdown'
 
 div(class=props.className onClick=this.submitForm)
+  if state.isShowingMessage
+    ConfirmDropdown(
+      cancelLabel=props.messageCancelLabel
+      confirmLabel=props.messageConfirmLabel
+      message=props.confirmMessage
+      onConfirmClick=this.sendForm
+      onCancelClick=props.onCancel
+      onHide=this.hideMessage
+      position=props.messagePosition
+      type=props.messageType)
   yield
 
 :module
+  export function getDefaultProps () {
+    return {
+      messageConfirmLabel: 'Confirm',
+      messageCancelLabel: 'Cancel',
+      messagePosition: 'bottom-middle'
+    };
+  }
+
+  export function showMessage () {
+    this.setState({isShowingMessage: true});
+  }
+
+  export function hideMessage () {
+    this.setState({isShowingMessage: false});
+  }
+
   export function submitForm() {
     if (this.props.confirmMessage) {
-      if (window.confirm(this.props.confirmMessage)) this.sendForm();
+      if (this.props.useSystemDialog && window.confirm(this.props.confirmMessage)) return this.sendForm();
+      return this.showMessage();
     } else {
       this.sendForm();
     }
@@ -20,10 +55,9 @@ div(class=props.className onClick=this.submitForm)
 
   export function sendForm () {
     if (this.props.onStart) this.props.onStart.apply(null, arguments);
-    var template = this.props.template;
-    this.context.forms.create(template)
+    this.context.forms.create(this.props.template)
       .submit((err, res) => {
-        if (err) this.setState({error: err});
+        err = err || res.error;
         if (this.props.onFinish) this.props.onFinish(err, res);
       });
   }

--- a/controls/submit/index.jade
+++ b/controls/submit/index.jade
@@ -57,7 +57,6 @@ div(class=props.className onClick=this.submitForm)
     if (this.props.onStart) this.props.onStart.apply(null, arguments);
     this.context.forms.create(this.props.template)
       .submit((err, res) => {
-        err = err || res.error;
         if (this.props.onFinish) this.props.onFinish(err, res);
       });
   }

--- a/skins/flyout/index.ess
+++ b/skins/flyout/index.ess
@@ -26,30 +26,27 @@
     & <-arrow
       margin-left 0.5rem
       %../icon/glyph-arrow/direction/up.ess
-&-is-position-left
-  %./position/left-middle.ess
-&-is-position-left-top
-  %./position/left-top.ess
-&-is-position-left-bottom
-  %./position/left-bottom.ess
-
-&-is-position-right
-  %./position/right-middle.ess
-&-is-position-right-top
-  %./position/right-top.ess
-&-is-position-right-bottom
-  %./position/right-bottom.ess
-
-&-is-position-bottom
-  %./position/bottom-middle.ess
-&-is-position-bottom-left
-  %./position/bottom-left.ess
-&-is-position-bottom-right
-  %./position/bottom-right.ess
-
-&-is-position-top
-  %./position/top-middle.ess
-&-is-position-top-left
-  %./position/top-left.ess
-&-is-position-top-right
-  %./position/top-right.ess
+&-menu-is-position-left-middle
+  %../../skins/flyout/position/left-middle.ess
+&-menu-is-position-left-top
+  %../../skins/flyout/position/left-top.ess
+&-menu-is-position-left-bottom
+  %../../skins/flyout/position/left-bottom.ess
+&-menu-is-position-right-middle
+  %../../skins/flyout/position/right-middle.ess
+&-menu-is-position-right-top
+  %../../skins/flyout/position/right-top.ess
+&-menu-is-position-right-bottom
+  %../../skins/flyout/position/right-bottom.ess
+&-menu-is-position-bottom-middle
+  %../../skins/flyout/position/bottom-middle.ess
+&-menu-is-position-bottom-left
+  %../../skins/flyout/position/bottom-left.ess
+&-menu-is-position-bottom-right
+  %../../skins/flyout/position/bottom-right.ess
+&-menu-is-position-top-middle
+  %../../skins/flyout/position/top-middle.ess
+&-menu-is-position-top-left
+  %../../skins/flyout/position/top-left.ess
+&-menu-is-position-top-right
+  %../../skins/flyout/position/top-right.ess

--- a/skins/flyout/position/bottom-left.ess
+++ b/skins/flyout/position/bottom-left.ess
@@ -1,3 +1,2 @@
-&-menu
-  top 100%
-  left 0
+top 100%
+left 0

--- a/skins/flyout/position/bottom-middle.ess
+++ b/skins/flyout/position/bottom-middle.ess
@@ -1,4 +1,4 @@
-&-menu
-  top 100%
-  left 50%
-  transform translate(-50%, 0%)
+top 100%
+left 50%
+margin-top 0.5rem
+transform translate(-50%, 0%)

--- a/skins/flyout/position/bottom-right.ess
+++ b/skins/flyout/position/bottom-right.ess
@@ -1,3 +1,2 @@
-&-menu
-  top 100%
-  right 0
+top 100%
+right 0

--- a/skins/flyout/position/left-bottom.ess
+++ b/skins/flyout/position/left-bottom.ess
@@ -1,3 +1,2 @@
-&-menu
-  right 100%
-  bottom 0
+right 100%
+bottom 0

--- a/skins/flyout/position/left-middle.ess
+++ b/skins/flyout/position/left-middle.ess
@@ -1,4 +1,3 @@
-&-menu
-  right 100%
-  top 50%
-  transform translate(0, -50%)
+right 100%
+top 50%
+transform translate(0, -50%)

--- a/skins/flyout/position/left-top.ess
+++ b/skins/flyout/position/left-top.ess
@@ -1,3 +1,2 @@
-&-menu
-  right 100%
-  top 0
+right 100%
+top 0

--- a/skins/flyout/position/right-bottom.ess
+++ b/skins/flyout/position/right-bottom.ess
@@ -1,3 +1,2 @@
-&-menu
-  left 100%
-  bottom 0
+left 100%
+bottom 0

--- a/skins/flyout/position/right-middle.ess
+++ b/skins/flyout/position/right-middle.ess
@@ -1,4 +1,3 @@
-&-menu
-  left 100%
-  top 50%
-  transform translate(0, -50%)
+left 100%
+top 50%
+transform translate(0, -50%)

--- a/skins/flyout/position/right-top.ess
+++ b/skins/flyout/position/right-top.ess
@@ -1,3 +1,2 @@
-&-menu
-  left 100%
-  top 0
+left 100%
+top 0

--- a/skins/flyout/position/top-left.ess
+++ b/skins/flyout/position/top-left.ess
@@ -1,3 +1,2 @@
-&-menu
-  bottom 100%
-  left 0
+bottom 100%
+left 0

--- a/skins/flyout/position/top-middle.ess
+++ b/skins/flyout/position/top-middle.ess
@@ -1,4 +1,3 @@
-&-menu
-  bottom 100%
-  left 50%
-  transform translate(-50%, 0)
+bottom 100%
+left 50%
+transform translate(-50%, 0)

--- a/skins/flyout/position/top-right.ess
+++ b/skins/flyout/position/top-right.ess
@@ -1,3 +1,2 @@
-&-menu
-  bottom 100%
-  right 0
+bottom 100%
+right 0


### PR DESCRIPTION
- Submit will now use confirm dropdown to show a message to the user,
unless `useSystemDialog` is passed.
- Submit onFinish will now pass err or res.error as the err arg
- Removed setState({error: err}) because it was not used
- Added specific functions to flyout so we can tell exactly how the
user interacted with the component to make it hide.

- Changes had to be made to flyout’s menu skins to make positioning
work from the Submit control:
— Positioning a flyout menu should now happen with the prop “position”
rather than with a skin. Otherwise, you will need to nest the skin
under `&-menu`