### PR TITLE
Keybindings now support multiple assignments

### DIFF
--- a/components/confirm/index.jade
+++ b/components/confirm/index.jade
@@ -12,13 +12,23 @@
   @prop {Function} [onHide] - Called any time this menu hides (including onConfirmClick)
   @prop {String} [type='delete'] - Types supported are delete or confirm
 
-import {attachKeybinding, removeKeybindings} from '../../utils/keybinding.js'
+import {attachKeybindings, removeKeybindings} from '../../utils/keybinding.js'
 import Flyout from '../../controls/flyout'
 import './index.ess'
 
 var classFn = this.composeClasses('UIConfirm', {'type-@':props.type, 'has-message': !!props.message})
 
-Flyout(className=classFn() scrollToMenuOptions=props.scrollToOptions scrollToMenu=props.scrollToMenu showMenuOnLoad onHide=props.onHide onKeybindingPress=this.onKeybindingPress onWindowClickHide=this.onCancelClick hideMenuKeyBinding=props.cancelKeybinding position=props.position)
+Flyout(
+  className=classFn()
+  hideMenuKeybinding=props.cancelKeybinding
+  onShow=this.onShow
+  onHide=this.onHide
+  onKeybindingPress=this.onKeybindingPress
+  onWindowClickHide=this.onCancelClick
+  position=props.position
+  scrollToMenu=props.scrollToMenu
+  scrollToMenuOptions=props.scrollToOptions
+  showMenuOnLoad)
   block menu(actions)
     if (props.message)
       div(className=classFn('UIConfirm-message'))
@@ -47,14 +57,8 @@ Flyout(className=classFn() scrollToMenuOptions=props.scrollToOptions scrollToMen
     }
   }
 
-  export function componentWillMount () {
-    if (this.props.confirmKeybinding) {
-      attachKeybinding(this.props.confirmKeybinding, this.onEnterPress);
-    }
-  }
-
   export function componentWillUnmount () {
-    removeKeybindings(this.props.confirmKeybinding);
+    removeKeybindings(this.props.confirmKeybinding, this.onEnterPress);
   }
 
   export function onCancelClick (hideDropdown) {
@@ -65,6 +69,15 @@ Flyout(className=classFn() scrollToMenuOptions=props.scrollToOptions scrollToMen
   export function onConfirmClick (hideDropdown) {
     if (hideDropdown) hideDropdown();
     if (this.props.onConfirmClick) this.props.onConfirmClick();
+  }
+
+  export function onShow () {
+    if (this.props.confirmKeybinding) attachKeybindings(this.props.confirmKeybinding, this.onEnterPress);
+  }
+
+  export function onHide () {
+    if (this.props.onHide) this.props.onHide();
+    removeKeybindings(this.props.confirmKeybinding, this.onEnterPress);
   }
 
   export function onEnterPress () {

--- a/controls/flyout/index.jade
+++ b/controls/flyout/index.jade
@@ -12,9 +12,9 @@
   @prop {Number}   [animationTimeout=0] number in ms to wait before removing menu, or sending false value for isActive
   @prop {Boolean}  [scrollToMenu=true] body will scroll to fully show menu when active
   @prop {Object}   [scrollToMenuOptions={}] custom options for scroll-to-element (incl. top/bottomOffset for offset when above/below the fold)
-  @prop {String}   [hideMenuKeyBinding] key to listen for that will hide flyout
-  @prop {String}   [showMenuKeyBinding] key to listen for that will show flyout
-  @prop {String}   [toggleMenuKeyBinding] key to listen for that will toggle flyout
+  @prop {String}   [hideMenuKeybinding] key to listen for that will hide flyout
+  @prop {String}   [showMenuKeybinding] key to listen for that will show flyout
+  @prop {String}   [toggleMenuKeybinding] key to listen for that will toggle flyout
   @prop {Function} [onShow] called after flyout shows
   @prop {Function} [onHide] called after flyout hides
   @prop {Function} [onWindowClickHide] this is called when flyout will hide because of clicking outside the menu (onHide will also be called)
@@ -25,7 +25,7 @@
 
 import * as scrollToElement from 'scroll-to-element'
 import elContains from '../../utils/element-contains-el'
-import {attachKeybinding, removeKeybindings, hasKeybinding} from '../../utils/keybinding.js'
+import {attachKeybindings, removeKeybindings, hasKeybinding} from '../../utils/keybinding.js'
 
 :js
   var classFn = this.composeClasses('UIFlyout', {
@@ -71,28 +71,24 @@ div(className=classFn())
   }
 
   export function componentDidMount () {
-    if (this.props.showMenuKeyBinding) {
-      attachKeybinding(this.props.showMenuKeyBinding, this.onKeybindingPress.bind(null, 'show'));
-    }
-    if (this.props.toggleMenuKeyBinding) {
-      attachKeybinding(this.props.toggleMenuKeyBinding, this.onKeybindingPress.bind(null, 'toggle'));
-    }
+    this.setKeybindings();
+    if (this.keybindings.show)   attachKeybindings(this.keybindings.show);
+    if (this.keybindings.toggle) attachKeybindings(this.keybindings.toggle);
     if (this.props.showMenuOnLoad) this.startShowingMenu();
   }
 
   export function componentWillReceiveProps (nextProps) {
-    if (nextProps.showMenuKeyBinding !== this.props.showMenuKeyBinding && hasKeybinding(this.props.showMenuKeyBinding)) {
-      removeKeybindings(this.props.showMenuKeyBinding);
-      attachKeybinding(nextProps.showMenuKeyBinding, this.onKeybindingPress.bind(null, 'show'));
+    if (!this.equalPairs(nextProps.showMenuKeybinding, this.props.showMenuKeybinding) ||
+        !this.equalPairs(nextProps.hideMenuKeybinding, this.props.hideMenuKeybinding) ||
+        !this.equalPairs(nextProps.toggleMenuKeybinding, this.props.toggleMenuKeybinding)) {
+      removeKeybindings(this.getKeybindings());
+      this.setKeybindings(nextProps);
+      if (this.state.isActive) attachKeybindings(this.keybindings.hide)
+      else attachKeybindings(Object.assign({},
+        this.keybindings.show || {},
+        this.keybindings.toggle || {}))
     }
-    if (nextProps.hideMenuKeyBinding !== this.props.hideMenuKeyBinding && hasKeybinding(this.props.hideMenuKeyBinding)) {
-      removeKeybindings(this.props.hideMenuKeyBinding);
-      attachKeybinding(nextProps.hideMenuKeyBinding, this.onKeybindingPress.bind(null, 'hide'));
-    }
-    if (nextProps.toggleMenuKeyBinding !== this.props.toggleMenuKeyBinding && hasKeybinding(this.props.toggleMenuKeyBinding)) {
-      removeKeybindings(this.props.toggleMenuKeyBinding);
-      attachKeybinding(nextProps.toggleMenuKeyBinding, this.onKeybindingPress.bind(null, 'toggle'));
-    }
+
     if (nextProps.showMenuOnLoad && !this.state.hasShownMenu) {
       this.startShowingMenu();
     }
@@ -120,8 +116,24 @@ div(className=classFn())
 
   export function componentWillUnmount () {
     window.removeEventListener('click', this.onWindowClick);
-    removeKeybindings([this.props.showMenuKeyBinding, this.props.hideMenuKeyBinding, this.props.toggleMenuKeyBinding]);
+    removeKeybindings(this.getKeybindings());
     if (this.state.isActive && this.props.onHide) this.props.onHide();
+  }
+
+  export function setKeybindings (nextProps) {
+    var props = nextProps || this.props;
+    var kb = {};
+    if (props.showMenuKeybinding)   kb.show   = {[props.showMenuKeybinding]  : this.onKeybindingPress.bind(null, 'show')};
+    if (props.hideMenuKeybinding)   kb.hide   = {[props.hideMenuKeybinding]  : this.onKeybindingPress.bind(null, 'hide')};
+    if (props.toggleMenuKeybinding) kb.toggle = {[props.toggleMenuKeybinding]: this.onKeybindingPress.bind(null, 'toggle')};
+    this.keybindings = kb;
+  }
+
+  export function getKeybindings () {
+    return Object.assign({},
+        this.keybindings.show   || {},
+        this.keybindings.hide   || {},
+        this.keybindings.toggle || {});
   }
 
   export function onKeybindingPress (action) {
@@ -148,8 +160,8 @@ div(className=classFn())
   export function startShowingMenu (evt) {
     if (this.state.isActive) return;
     if (this.props.onComponentWillShow) this.props.onComponentWillShow();
-    if (this.props.showMenuKeyBinding) removeKeybindings(this.props.showMenuKeyBinding);
-    if (this.props.hideMenuKeyBinding) attachKeybinding(this.props.hideMenuKeyBinding, this.onKeybindingPress.bind(null, 'hide'));
+    if (this.keybindings.show) removeKeybindings(this.keybindings.show);
+    if (this.keybindings.hide) attachKeybindings(this.keybindings.hide);
     this.setState({showMenuStarted: true, hasShownMenu: true});
   }
 
@@ -157,8 +169,8 @@ div(className=classFn())
     if (!this.state.isActive) return;
     if (evt) evt.stopPropagation();
     if (this.props.onComponentWillHide) this.props.onComponentWillHide();
-    if (this.props.hideMenuKeyBinding) removeKeybindings(this.props.hideMenuKeyBinding);
-    if (this.props.showMenuKeyBinding) attachKeybinding(this.props.showMenuKeyBinding, this.onKeybindingPress.bind(null, 'show'));
+    if (this.keybindings.hide) removeKeybindings(this.keybindings.hide);
+    if (this.keybindings.show) attachKeybindings(this.keybindings.show);
     this.setState({hideMenuStarted: true});
     window.removeEventListener('click', this.onWindowClick);
   }

--- a/controls/submit/index.jade
+++ b/controls/submit/index.jade
@@ -17,7 +17,10 @@ div(class=props.className onClick=!state.isShowingConfirm ? this.submitForm : nu
   }
 
   export function hideMessage () {
-    this.setState({isShowingConfirm: false});
+    // setTimeout so confirm still belongs to submit through the click event (i.e. confirming in flyouts)
+    setTimeout(() => {
+      if (this.isMounted()) this.setState({isShowingConfirm: false});
+    }, 100);
   }
 
   export function submitForm () {
@@ -30,7 +33,7 @@ div(class=props.className onClick=!state.isShowingConfirm ? this.submitForm : nu
   }
 
   export function sendForm () {
-    this.hideMessage();
+    if (this.state.isShowingConfirm) this.hideMessage();
     if (this.props.onStart) this.props.onStart.apply(null, arguments);
     this.context.forms.create(this.props.template)
       .submit((err, res) => {

--- a/utils/keybinding.js
+++ b/utils/keybinding.js
@@ -1,4 +1,5 @@
 var bindings = {};
+var windowMethods = {};
 var KEY_NAMES = {
   'backspace': 8,
   'enter': 13,
@@ -6,39 +7,84 @@ var KEY_NAMES = {
 };
 
 exports.KEY_NAMES = KEY_NAMES;
+exports.hasKeybinding = hasKeybinding;
+exports.attachKeybindings = exports.attachKeybinding = attachKeybindings;
+exports.removeKeybindings = exports.removeKeybinding = removeKeybindings;
 
-exports.attachKeybinding = function (char, callback) {
-  if (!char || !callback) return console.warn('attachKeybinding requires character and callback.');
-  if (bindings[char]) return console.warn('keybinding for "' + char + '" already exists.');
-  var handler = bindings[char] = keyupHandler.bind(null, char, callback);
-  window.addEventListener('keyup', handler);
+//- Function to call when adding keybindings
+//- @arg {String} bindings - the character key to be bound
+//-   || {Object} bindings - the character to listen for as the key, method as the value {[character]: method}
+//- @arg {Function} method - the callback handler to call when string is passed to bindings
+function attachKeybindings (binding, method) {
+  if (!binding) return console.warn('attachKeybinding requires character or object for binding');
+  if (typeof binding === 'string' && !method) console.warn('attachKeybindings requries method as second arg');
+  if (hasKeybinding(binding, method)) return console.warn(`attachKeybinding: already attached ${binding} to method`, method);
+
+  if (typeof binding === 'string') addMethod(binding, method);
+  else Object.keys(binding).forEach((key) => addMethod(key, binding[key]))
 }
 
-// keys can be array of strings or single string
-exports.removeKeybindings = function (keys) {
-  var item, handler;
-  if (Array.isArray(keys)) {
-    for (var i in keys) {
-      item = keys[i];
-      handler = bindings[item];
-      if (handler) {
-        window.removeEventListener('keyup', handler);
-        delete bindings[item];
-      }
-    }
-  } else {
-    window.removeEventListener('keyup', bindings[keys]);
-    delete bindings[keys];
+//- Function to call to remove keybindings
+//- @arg {String} bindings - the character key to be removed
+//    || {Object} bindings - the character to remove, with method as the value {[character]: method}
+//- @arg {Function} method - the callback handler to call when string is passed to bindingsr
+function removeKeybindings (bindings, method) {
+  if (typeof bindings === 'string' && !method) console.warn('removeKeybindings requries method as second arg');
+  if (typeof bindings === 'string') return removeMethod(bindings, method);
+  Object.keys(bindings).forEach((key) => removeMethod(key, bindings[key]));
+}
+
+//- Adds the event to window and the methods to bindings and windowMethods
+//- @arg {String} char     - the character key to be bound
+//- @arg {Function} method - the callback handler to call
+function addMethod (char, method) {
+  var keyIsBound = hasKeybinding(char);
+  var boundHandler = keyupHandler.bind(null, char, method);
+
+  bindings[char] = bindings[char] || [];
+  windowMethods[char] = windowMethods[char] || [];
+
+  if (keyIsBound) window.removeEventListener('keyup', windowMethods[char][0]);
+
+  bindings[char].unshift(method);
+  windowMethods[char].unshift(boundHandler);
+
+  window.addEventListener('keyup', boundHandler);
+}
+
+//- Removes the event from window and the methods from bindings and windowMethods
+//- @arg {String} char     - the character key to be removed
+//- @arg {Function} method - the callback handler to remove
+function removeMethod (char, method) {
+  if (!hasKeybinding(char, method)) return;
+  var fnIndex = bindings[char].indexOf(method);
+  window.removeEventListener('keyup', windowMethods[char][fnIndex]);
+  bindings[char].splice(fnIndex, 1);
+  windowMethods[char].splice(fnIndex, 1);
+
+  if (!bindings[char].length) {
+    delete bindings[char];
+    delete windowMethods[char];
+  } else if (fnIndex === 0) {
+    window.addEventListener('keyup', windowMethods[char][0]);
   }
 }
 
-exports.hasKeybinding = function (key) {
-  return !!bindings[key];
+//- Returns Boolean if key is bound to a method, or if any bindings exist for that character
+//- @arg {String} key - character in question
+//- @arg {Function} method - used when you want to know if a key has been bound to a method.
+function hasKeybinding (key, method) {
+  if (!bindings[key]) return false;
+  return method ? !!~bindings[key].indexOf(method) : true;
 }
 
-function keyupHandler (matchChar, callback, evt) {
-  // we don't want to fire events when somebody is typing in an input, esc is okay to fire
+// The method we call to parse the event for the key pressed
+//- @arg {String}   matchChar - the character to match
+//- @arg {Function} method    - function to call when the key specified is pressed
+//- @arg {Object}   evt       - default browser keyup event
+function keyupHandler (matchChar, method, evt) {
+  // except for esc, we don't want to fire events when somebody is typing in an input
   if ((evt.target.tagName !== 'INPUT' && evt.target.tagName !== 'TEXTAREA' && !evt.target.hasAttribute('contenteditable')) || evt.keyCode === KEY_NAMES.esc) {
-    if (evt.keyCode === KEY_NAMES[matchChar] || String.fromCharCode(evt.keyCode) === matchChar.toUpperCase()) callback.apply(null);
+    if (evt.keyCode === KEY_NAMES[matchChar] || String.fromCharCode(evt.keyCode) === matchChar.toUpperCase()) method(evt);
   }
 }


### PR DESCRIPTION
- Updated convention for keyBinding vs keybinding (the latter won)
- Importing either singular or plural version of
attach/removeKeybindings will work
- First arg for attach/remove can now be an object with the key as the
character and method as the value; or it can be the character string
with the second arg as the method.
- removeKeybindings now requires you to pass a method with the
character you want to remove.